### PR TITLE
Improved the language following the anon-func example.

### DIFF
--- a/functions.md
+++ b/functions.md
@@ -117,9 +117,10 @@ follows:
 {callout="//"}
 <{{src/functions/anon-func.go}}[3,]
 
-Define a nameless function and assign to `a`. No `()` here. If there were we
-would *call* the function in `a`.
-*Now* we call the function.
+`a` is defined as an anonymous (nameless) function. 
+Note the lack of parentheses `()` after `a`. If there were, that would be to *call*
+some function with the name `a` before we have defined what `a` is. Once `a` is 
+defined, then we can *call* it.
 
 Functions--as--values may be used in other places, for example maps. Here we
 convert from integers to functions:


### PR DESCRIPTION
It was unnecessarily awkward and compressed to read, plus the less than ideal use of `a` and "a" in the same sentence... using markup to try to fix a writing problem. Alternatively, one could change the example code to use something like `x` or `f` instead of `a`.
In any case, whilst an overly conversational style can be draining and actually hide details, sentences still need to breathe. It's for a person to read, not for a person to *parse* - and even it were, the context to be inferred is a little unreasonable.

What is still missing is something mentioning that functions-as-values don't have to be anonymous, which is what could be inferred from this block of text with the example. There should ideally be an example that defines a global function (instance?) for recursive use, say. Even steal the example from the Go Tour?