### PR TITLE
Remove invalid switch cases for interface example

### DIFF
--- a/interfaces.md
+++ b/interfaces.md
@@ -91,7 +91,9 @@ figure that out by using a type switch ((type switch)).
 At <1> we use the type switch, note that the `.(type)` syntax in *only* valid
 within a `switch` statement. We store the type in the variable `t`. The
 subsequent cases <2> each check for a different *actual* type. And we can even
-have a `default` <3> clause.
+have a `default` <3> clause. It is worth pointing out that both `case R` and
+`case s` aren't possible, because `p` needs to be a pointer in order to satisfy
+`i`.
 
 A type switch isn't the only way to discover the type at *run-time*.
 

--- a/interfaces.md
+++ b/interfaces.md
@@ -84,8 +84,6 @@ figure that out by using a type switch ((type switch)).
         switch t := p.(type) { //<1>
             case *S: //<2>
             case *R: //<2>
-            case S:  //<2>
-            case R:  //<2>
             default: //<3>
         }
     }


### PR DESCRIPTION
Thanks for the great book, @miekg!

Is it possible that there's a little issue with the example on switching by `p.(type)` [here](https://github.com/miekg/learninggo/blob/master/interfaces.md#which-is-what)? Following the example leads to code that's not compiling:
```go
package main

import "fmt"

type S struct{ i int }

func (s *S) Get() int  { return s.i }
func (s *S) Put(n int) { s.i = n }

type R struct{ i int }

func (s *R) Get() int  { return s.i }
func (s *R) Put(n int) { s.i = n }

type I interface {
	Get() int
	Put(int)
}

func f(p I) {
	switch p.(type) {
	case *S:
		fmt.Println("It's an *S")
	case *R:
		fmt.Println("It's an *R")
	}
}

func main() {
    s := S{}
    f(&s)
}

```
Running it yields errors:
```bash
$ go run main.go
# command-line-arguments
./main.go:26: impossible type switch case: p (type I) cannot have dynamic type S (missing Get method)
./main.go:28: impossible type switch case: p (type I) cannot have dynamic type R (missing Get method)
```

I am just starting to learn the ropes. But I think the issue is that both `case S` and `case R` aren't possible, because `Put(int)` requires a pointer rather than the value. Please, check my fix.