### PR TITLE
Fix cat solution to handle no newlines

### DIFF
--- a/ex/beyond/src/cat2.go
+++ b/ex/beyond/src/cat2.go
@@ -14,7 +14,7 @@ func cat(r *bufio.Reader) {
 	i := 1
 	for {
 		buf, e := r.ReadBytes('\n')
-		if e == io.EOF {
+		if e == io.EOF && string(buf) == "" {
 			break
 		}
 		if *numberFlag {


### PR DESCRIPTION
Only break if there's no content to send to standard output.

Fixes #21.