### PR TITLE
Make comment prefix // display

### DIFF
--- a/src/basics/helloworld.go
+++ b/src/basics/helloworld.go
@@ -1,6 +1,6 @@
 package main //<1>
 
-import "fmt" //<2> Implements formatted I/O. 
+import "fmt" //<2> //// Implements formatted I/O.
 
 /* Print something */ <3>
 func main() { //<4>


### PR DESCRIPTION
The comment prefix `//` disappears in the callout rendering, so force one to remain so the statement "The line ends with a comment that begins with //." is represented.