### PR TITLE
Hyperlinks to headers fixed; font changes

### DIFF
--- a/basics.md
+++ b/basics.md
@@ -208,7 +208,7 @@ now you can just assume that `error` is a type just like all other types.
 
 ## Operators and Built-in Functions
 
-Go supports the normal set of numerical operators. See [Precedence](#tab-op-precedence)
+Go supports the normal set of numerical operators. See [Table: Precedence](#tab-op-precedence)
 for lists the current ones and their relative precedence. They all associate from
 left to right.
 
@@ -229,7 +229,7 @@ concatenating them).
 
 
 ## Go Keywords
-Let's start looking at keywords, [Keywords](#tab-keywords) lists all the keywords in
+Let's start looking at keywords, [Table: Keywords](#tab-keywords) lists all the keywords in
 Go.
 
 {#tab-keywords}
@@ -475,7 +475,7 @@ You can list cases on one line <1>, separated by commas.
 
 ## Built-in Functions
 A few functions are predefined, meaning you *don't* have to include any package
-to get access to them. [Functions](#tab-predef-functions) lists them all.^[You can
+to get access to them. [Table: Pre-defined functions](#tab-predef-functions) lists them all.^[You can
 use the command `godoc builtin` to read the online documentation about the
 built-in types and functions.]
 
@@ -588,7 +588,7 @@ passing a pointer to the underlying array. With: `slice := make([]int, 10)`, you
 create a slice which can hold ten elements. Note that the underlying array isn't
 specified. A slice is always coupled to an array that has a fixed size. For
 slices we define a capacity (((slice,capacity))) and a length
-(((slice,length))). [Array versus slice](#fig-array-vs-slice) shows the creation of an array,
+(((slice,length))). [Figure:Array versus slice](#fig-array-vs-slice) shows the creation of an array,
 then the creation of a slice. First we create an array of $$m$$ elements of the
 type `int`: `var array[m]int` .
 

--- a/basics.md
+++ b/basics.md
@@ -22,7 +22,7 @@ a standalone executable.
 
 `import "fmt"` says we need `fmt` in addition to `main` <2>. A package other
 than `main` is commonly called a library, a familiar concept in many programming
-languages (see (#packages)). The line ends with a comment that begins with `//`.
+languages (see [Packages](#packages)). The line ends with a comment that begins with `//`.
 
 Next we another comment, but this one is enclosed in `/*` `*/` <3>. When your Go
 program is executed, the first function called will be `main.main()`, which
@@ -71,7 +71,7 @@ a value to it. The code on the right uses `:=` to do this in one step (this form
 may only be used *inside* functions). In that case the variable type is
 *deduced* from the value. A value of 15 indicates an `int`. A value of `false`
 tells Go that the type should be `bool`. Multiple `var` declarations may also
-be grouped; `const` (see (#constants)) and `import` also allow this. Note the
+be grouped; `const` (see [Constants](#constants)) and `import` also allow this. Note the
 use of parentheses instead of braces:
 
 ~~~go
@@ -202,13 +202,13 @@ is the real part, `im` is the imaginary part and $$i$$ is the literal '$$i$$'
 Any non-trivial program will have the need for error reporting sooner or later.
 Because of this Go has a builtin type specially for errors, called `error`. `var
 e error` creates a variable `e` of type `error` with the value `nil`. This error
-type is an interface -- we'll look more at interfaces in (#interfaces). For
+type is an interface -- we'll look more at interfaces in [Interfaces](#interfaces). For
 now you can just assume that `error` is a type just like all other types.
 
 
 ## Operators and Built-in Functions
 
-Go supports the normal set of numerical operators. See (#tab-op-precedence)
+Go supports the normal set of numerical operators. See [Precedence](#tab-op-precedence)
 for lists the current ones and their relative precedence. They all associate from
 left to right.
 
@@ -229,30 +229,30 @@ concatenating them).
 
 
 ## Go Keywords
-Let's start looking at keywords, (#tab-keywords) lists all the keywords in
+Let's start looking at keywords, [Keywords](#tab-keywords) lists all the keywords in
 Go.
 
 {#tab-keywords}
 {{tab/keywords.md}}
 
-We've seen some of these already. We used `var` and `const` in the (#variables-types-and-keywords)
+We've seen some of these already. We used `var` and `const` in the [Variables, Types and Keywords](#variables-types-and-keywords)
 section,  and we briefly looked at `package` and `import` in our "Hello World"
 program at the start of the chapter. Others need more attention and have their
 own chapter or section:
 
 * `func` is used to declare functions and methods.
-* `return` is used to return from functions. We'll look at both `func` and `return` in detail in (#functions).
-* `go` is used for concurrency. We'll look at this in (#channels).
-* `select` used to choose from different types of communication, We'll work with `select` in (#channels).
-* `interface` is covered in (#interfaces).
-* `struct` is used for abstract data types. We'll work with `struct` in (#beyond-the-basics).
-* `type` is also covered in (#beyond-the-basics).
+* `return` is used to return from functions. We'll look at both `func` and `return` in detail in [Functions](#functions).
+* `go` is used for concurrency. We'll look at this in [Channels](#channels).
+* `select` used to choose from different types of communication, We'll work with `select` in [Channels](#channels).
+* `interface` is covered in [Interfaces](#interfaces).
+* `struct` is used for abstract data types. We'll work with `struct` in [Beyond the basics](#beyond-the-basics).
+* `type` is also covered in [Beyond the basics](#beyond-the-basics).
 
 
 ## Control Structures
 There are only a few control structures in Go. To write loops we use the `for`
 keyword, and there is a `switch` and of course an `if`. When working with
-channels `select` will be used (see (#channels)). Parentheses are are not
+channels `select` will be used (see [Channels](#channels)). Parentheses are are not
 required around the condition, and the body must *always* be brace-delimited.
 
 
@@ -375,7 +375,7 @@ accepts a label.
 
 ### Range
 The keyword `range` (((keywords, range))) can be used for loops. It can loop
-over slices, arrays, strings, maps and channels (see (#channels)). `range` is an
+over slices, arrays, strings, maps and channels (see [Channels](#channels)). `range` is an
 iterator that, when called, returns the next key-value pair from the "thing" it
 loops over. Depending on what that is, `range` returns different things.
 
@@ -475,7 +475,7 @@ You can list cases on one line <1>, separated by commas.
 
 ## Built-in Functions
 A few functions are predefined, meaning you *don't* have to include any package
-to get access to them. (#tab-predef-functions) lists them all.^[You can
+to get access to them. [Functions](#tab-predef-functions) lists them all.^[You can
 use the command `godoc builtin` to read the online documentation about the
 built-in types and functions.]
 
@@ -487,7 +487,7 @@ pseudo package that is included in recent Go releases. Let's go over these
 functions briefly.
 
 `close`
-:   is used in channel communication. It closes a channel. We'll learn more about this in (#channels).
+:   is used in channel communication. It closes a channel. We'll learn more about this in [Channels](#channels).
     (((built-in,close)))
 
 `delete`
@@ -496,25 +496,25 @@ functions briefly.
 `len` and `cap`
 :   are used on a number of different types, `len` is
     used to return the lengths of strings, slices, and
-    arrays. In the next section (#arrays) we'll look at slices,
+    arrays. In the next section [Arrays](#arrays) we'll look at slices,
     arrays and the function `cap`.(((built-in,len)))(((built-in,cap)))
 
 `new`
 :   is used for allocating memory for user defined
-    data types. See (#allocation-with-new).
+    data types. See [Allocation with new](#allocation-with-new).
     (((built-in,new)))
 
 `make`
 :   is used for allocating memory for built-in
-    types (maps, slices, and channels). See (#allocation-with-make).
+    types (maps, slices, and channels). See [Allocation with make](#allocation-with-make).
     (((built-in,make)))
 
 `copy`, `append`
 :   `copy` is for copying slices. (((built-in,copy)))
-    And `append` is for concatenating slices. See (#slices) in this chapter. (((built-in,append)))
+    And `append` is for concatenating slices. See [Slices](#slices) in this chapter. (((built-in,append)))
 
 `panic`, `recover`
-:   are used for an *exception* mechanism. See (#panic-and-recovering) for more.
+:   are used for an *exception* mechanism. See [Panic and recovering](#panic-and-recovering) for more.
     (((built-in,panic)))
     (((built-in,recover)))
 
@@ -562,7 +562,7 @@ a [3]int`. To initialize it to something other than zero, use a
 
 A> A composite literal allows you
 A> to assign a value directly to an array, slice, or map.
-A> See (#constructors-and-composite-literals) for more information.
+A> See [Constructors and composite literals](#constructors-and-composite-literals) for more information.
 
 When declaring arrays you *always* have to type something in between the square
 brackets, either a number or three dots (`...`), when using a composite literal.
@@ -579,7 +579,7 @@ arrays is that a slice is a pointer *to* an array; slices are reference
 types.(((reference types)))
 
 A> Reference types are created with `make`. We detail this further
-A> in (#beyond-the-basics).
+A> in [Beyond the basics](#beyond-the-basics).
 
 That means that if you assign one slice to another, both refer to the *same*
 underlying array. For instance, if a function takes a slice argument, changes it
@@ -588,7 +588,7 @@ passing a pointer to the underlying array. With: `slice := make([]int, 10)`, you
 create a slice which can hold ten elements. Note that the underlying array isn't
 specified. A slice is always coupled to an array that has a fixed size. For
 slices we define a capacity (((slice,capacity))) and a length
-(((slice,length))). (#fig-array-vs-slice) shows the creation of an array,
+(((slice,length))). [Array versus slice](#fig-array-vs-slice) shows the creation of an array,
 then the creation of a slice. First we create an array of $$m$$ elements of the
 type `int`: `var array[m]int` .
 

--- a/beyond.md
+++ b/beyond.md
@@ -231,7 +231,7 @@ struct {
 Note that field names that start with a capital letter are exported, i.e. can be
 set or read from other packages. Field names that start with a lowercase are
 private to the current package. The same goes for functions defined in packages,
-see (#packages) for the details.
+see [Packages](#packages) for the details.
 
 
 ### Methods
@@ -244,7 +244,7 @@ routes:
 func doSomething(n1 *NameAge, n2 int) { /* */ }
 ~~~
 
-2. Create a function that works on the type (see *receiver* in (#functions)):
+2. Create a function that works on the type (see *receiver* in [Functions](#functions)):
 
 ~~~go
 func (n1 *NameAge) doSomething(n2 int) { /* */ }

--- a/ex/basics/strings.md
+++ b/ex/basics/strings.md
@@ -23,7 +23,7 @@ In addition, make it output the number of bytes in that string.
 position 4 with 'abc'.
 
 4. Write a Go program that reverses a string, so "foobar" is printed as "raboof".
-*Hint*: You will need to know about conversion; skip ahead to (#conversions).
+*Hint*: You will need to know about conversion; skip ahead to [Conversions](#conversions).
 
 
 {.answer}

--- a/ex/beyond/pointers-method.md
+++ b/ex/beyond/pointers-method.md
@@ -56,4 +56,4 @@ In other words because `k1` is addressable and
 `*vector.IntVector` *does* have the `Push` method, the
 call `k1.Push(2)` is translated by Go into
 `(&k1).Push(2)` which makes the type system happy again (and
-you too -- now you know this).^[Also see (#methods) in this chapter.]
+you too -- now you know this).^[Also see [Methods](#methods) in this chapter.]

--- a/ex/channels/fib.md
+++ b/ex/channels/fib.md
@@ -1,7 +1,7 @@
 {.exercise data-difficulty="2"}
 ### Fibonacci II
 
-This is the same exercise as an earlier one (#fibonacci) in
+This is the same exercise as an earlier one [Fibbonacci](#fibonacci) in
 exercise. For completeness the complete question:
 
 > The Fibonacci sequence starts as follows: $$1, 1, 2, 3, 5, 8, 13, \ldots$$

--- a/ex/channels/for-channels.md
+++ b/ex/channels/for-channels.md
@@ -1,7 +1,7 @@
 {.exercise data-difficulty="1"}
 ### Channels
 
-1. Modify the program you created in exercise (#forloop) to use
+1. Modify the program you created in exercise [For-loop](#forloop) to use
    channels, in other words, the function called in the body should now be
    a goroutine and communication should happen via channels. You should not
    worry yourself on how the goroutine terminates.

--- a/ex/functions/funcfunc.md
+++ b/ex/functions/funcfunc.md
@@ -9,7 +9,7 @@
     fmt.Printf("%v\n", p(2))
     ~~~
 
-    Which should print 4. See (#callbacks).
+    Which should print 4. See [Callbacks](#callbacks).
 
 2. Generalize the function from above and create a `plusX(x)` which returns functions that add `x` to an integer.
 

--- a/functions.md
+++ b/functions.md
@@ -23,7 +23,7 @@ func (p mytype) funcname(q int) (r,s int) { return 0,0 }
 To declare a function, you use the `func` keyword <1>. You can optionally bind
 <2> to a specific type called receiver (((functions, receiver))) (a function
 with a receiver is usually called a method(((functions, method)))). This will
-be explored in (#interfaces). Next <3> you write the name of your
+be explored in [Interfaces](#interfaces). Next <3> you write the name of your
 function. Here <4> we define that the variable `q` of type `int` is the input
 parameter. Parameters are passed *pass-by-value*.(((functions, pass-by-value)))
 The variables `r` and `s` <5> are the *named return parameters* (((functions,
@@ -52,7 +52,7 @@ The names are not mandatory but they can make code shorter and clearer:
 Functions can be declared in any order you wish. The compiler scans the entire
 file before execution, so function prototyping is a thing of the past in Go. Go
 does not allow nested functions, but you can work around this with anonymous
-functions. See the Section (#functions-as-values) in this chapter. Recursive
+functions. See the Section [Functions as values](#functions-as-values) in this chapter. Recursive
 functions work just as in other languages:
 
 {callout="//"}
@@ -142,7 +142,7 @@ Note that the final comma on second to last line is *mandatory*.
 
 Or you can write a function that takes a function as its parameter, for example
 a `Map` function that works on `int` slices. This is left as an exercise for the
-reader; see the exercise (#map-function).
+reader; see the exercise [Map function](#map-function).
 
 
 ## Callbacks
@@ -302,7 +302,7 @@ index as returned by `range`, hence the use of the underscore there. In the body
 of the `range` we just print the parameters we were given.
 
 If you don't specify the type of the variadic argument it defaults to the empty
-interface `interface{}` (see Chapter (#interfaces)).
+interface `interface{}` (see Chapter [Interfaces](#interfaces)).
 
 Suppose we have another variadic function called `myfunc2`, the following
 example shows how to pass variadic arguments to it:
@@ -360,7 +360,7 @@ func Panic(f func()) (b bool) { //<1>
 ~~~
 
 We define a new function `Panic` <1> that takes a function as an argument (see
-(#functions-as-values)). It returns true if `f` panics when run, else false. We
+[Functions as values](#functions-as-values)). It returns true if `f` panics when run, else false. We
 then <2> define a `defer` function that utilizes `recover`. If the current
 goroutine panics, this defer function will notice that. If `recover()` returns
 non-`nil` we set `b` to true. At <3> Execute the function we received as the

--- a/inc/orderedlist-minimal.css
+++ b/inc/orderedlist-minimal.css
@@ -1,11 +1,8 @@
-@import url(https://fonts.googleapis.com/css?family=Lato:400italic,700italic,400,700);
-
 body {
   padding:50px;
   max-width: 800px;
   margin-left: auto;
   margin-right: auto;
-  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
   color:#222;
   font-weight:400;
 }
@@ -68,9 +65,9 @@ blockquote {
 }
 
 code, pre {
-  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
+  font-family:monospace;
   color:#333;
-  font-size:14px;
+  font-size:16px;
   -moz-tab-size: 4;
   -o-tab-size: 4;
   tab-size: 4;
@@ -260,14 +257,14 @@ footer {
 
 @media print, screen {
   body {
-    font-size: 16px;
+    font-size: 18px;
   }
 }
 
 @media print, screen and (max-width: 720px) {
   body {
     word-wrap:break-word;
-    font-size: 15px;
+    font-size: 17px;
   }
 
   header {
@@ -285,7 +282,7 @@ footer {
 
 @media print, screen and (max-width: 480px) {
   body {
-    font-size: 14px;
+    font-size: 16px;
     padding:15px;
   }
 

--- a/interfaces.md
+++ b/interfaces.md
@@ -157,7 +157,7 @@ method.
 
 ## Methods
 
-Methods are functions that have a receiver (see (#functions)).
+Methods are functions that have a receiver (see [Functions](#functions)).
 You can define methods on any type (except on non-local types, this includes
 built-in types: the type `int` can not have methods).
 You can however make a new integer type with its own methods. For example:

--- a/introduction.md
+++ b/introduction.md
@@ -25,7 +25,7 @@ Concurrent
     run as *very* lightweight threads. These threads are called
     goroutines (((goroutine)))^[Yes, that sounds a lot like
     *co*routines, but goroutines are slightly different as we will
-    see in (#communication).] in Go.
+    see in [Communication](#communication).] in Go.
 
 Channels
 :   Communication with these goroutines is done, either via shared state or
@@ -80,29 +80,29 @@ these are marked with an asterisk.
 
 Here's what you can expect from each chapter:
 
-(#basics)
+[Basics](#basics)
 :   We'll look at the basic types, variables, and control structures available in the language.
 
-(#functions)
+[Functions](#functions)
 :   Here we look at functions, the basic building blocks of Go programs.
 
-(#packages)
+[Packages](#packages)
 :   We'll see that functions and data can be grouped together
     in packages. We'll also see how to document and test our packages.
 
-(#beyond-the-basics)
+[Beyond the basics](#beyond-the-basics)
 :   We'll create our own types. We'll also look at memory allocations in Go.
 
-(#interfaces)
+[Interfaces](#interfaces)
 :   We'll learn how to use interfaces. Interfaces are the central concept in Go,
     as Go does not support object orientation in the traditional sense.
 
-(#concurrency)
+[Concurrency](#concurrency)
 :   We'll learn the `go` keyword, which can be used to start function in
     separate routines (called goroutines). Communication with those goroutines is
     done via channels.
 
-(#communication)
+[Communication](#communication)
 :   Finally we'll see how to interface with the rest of the world from within
     a Go program. We'll see how to create files and read and write to and from them.
     We'll also briefly look into networking.

--- a/packages.md
+++ b/packages.md
@@ -22,7 +22,7 @@ our package (more on that later). The function `odd` <3> does not start with
 a capital letter, so it is a *private* function.
 
 Now we just need to build the package. We create a directory under `$GOPATH`,
-and copy `even.go` there (see (#compiling-and-running-code) in (#basics)).
+and copy `even.go` there (see [Compiling and Running Code](#compiling-and-running-code) in [Basics](#basics)).
 
     % mkdir $GOPATH/src/even
     % cp even.go $GOPATH/src/even
@@ -337,7 +337,7 @@ a mention: ^[The descriptions are copied from the packages' `go doc`.]
     manipulate objects with arbitrary types.  The typical use is to take a
     value with static type `interface{}` and extract its dynamic type
     information by calling `TypeOf`, which returns an object with interface
-    type `Type`. See (#interfaces), Section (#introspection-and-reflection).
+    type `Type`. See [Interfaces](#interfaces), Section [Introspection and reflection](#introspection-and-reflection).
 
 `os/exec`
 :   (((package, os/exec))) The `os/exec` package runs external commands.


### PR DESCRIPTION
- Hyperlinks to headers were missing. Fixed those; link text is exactly the same as the chapter name.
- Removed remote fonts. This lets the reader read the book in a font that they are comfortable in. Adheres to bettermotherfuckingwebsite.com guidelines.