### PR TITLE
Include maps as a data type that supports len function

### DIFF
--- a/basics.md
+++ b/basics.md
@@ -495,7 +495,7 @@ functions briefly.
 
 `len` and `cap`
 :   are used on a number of different types, `len` is
-    used to return the lengths of strings, slices, and
+    used to return the lengths of strings, maps, slices, and
     arrays. In the next section (#arrays) we'll look at slices,
     arrays and the function `cap`.(((built-in,len)))(((built-in,cap)))
 


### PR DESCRIPTION
This updates the book to include `maps` as a type that supports `len()`.